### PR TITLE
Allow for explicit interface enumeration for multi-network environments

### DIFF
--- a/terraform/cluster/config.tf
+++ b/terraform/cluster/config.tf
@@ -8,6 +8,16 @@ variable "cluster_domain" {
   type = "string"
 }
 
+variable "provisioning_interface" {
+  type = "string"
+  default = ""
+}
+
+variable "baremetal_interface" {
+  type = "string"
+  default = ""
+}
+
 variable "bootstrap_ign_file" {
   type = "string"
 }

--- a/terraform/cluster/main.tf
+++ b/terraform/cluster/main.tf
@@ -6,7 +6,9 @@ locals {
     "console=ttyS0,115200n8",
     "console=ttyS1,115200n8",
     "rd.neednet=1",
-    "nameserver=${var.nameserver}"
+    "nameserver=${var.nameserver}",
+    (var.provisioning_interface != "" ? "ip=${var.provisioning_interface}:dhcp" : " "),
+    (var.baremetal_interface != "" ? "ip=${var.baremetal_interface}:dhcp" : " "),
 
     # "rd.break=initqueue"
     "coreos.inst=yes",

--- a/terraform/cluster/terraform.tfvars.example
+++ b/terraform/cluster/terraform.tfvars.example
@@ -7,6 +7,14 @@ bootstrap_ign_file = "/path/to/local/bootstrap.ign"
 cluster_domain = "cluster.domain"
 cluster_id="cluster_name"
 
+// Interfaces
+// If you are using two networks (provisioning and baremetal), uncomment and
+// set these variables to corresponding names of the interfaces for those 
+// networks.  Failing to do so can prevent CoreOS ignition from working properly, 
+// especially on target machines with many interfaces.
+//provisioning_interface = "em1"
+//baremetal_interface = "em2"
+
 // The number of control plane machines required.
 //
 // Since etcd is colocated on control plane machines, suggested number is 3 or 5.


### PR DESCRIPTION
When using machines with multiple interfaces attached to multiple networks, it is possible, given the particular hardware/BIOS, that CoreOS might need explicit kernel args to know which interfaces to use for DHCP, routing and name servers.  These new variables allow the user to specify this.  It also has the beneficial side-effect of making the boot process faster, as the explicit enumeration of the proper DHCP interfaces precludes CoreOS potentially going through all interfaces for DHCP (in our lab, this dropped 5 minutes off the total deploy time).